### PR TITLE
Bump giter8 to 0.8.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,6 @@ import Keys._
 
 object Dependencies {
   lazy val templateResolverApi = "org.scala-sbt" % "template-resolver" % "0.1"
-  lazy val giter8 = "org.foundweekends.giter8" %% "giter8" % "0.7.2"
+  lazy val giter8 = "org.foundweekends.giter8" %% "giter8" % "0.8.0"
   lazy val launcherInterface = "org.scala-sbt" % "launcher-interface" % "1.0.0-M1"
 }


### PR DESCRIPTION
This should enable use of some of the `0.8.0` features that I'm looking forward too - including the subdirectory template feature.