### PR TITLE
Fixing #7 by checking for .g8.git instead of just .g8

### DIFF
--- a/src/main/scala/sbt/Giter8TemplateResolver.scala
+++ b/src/main/scala/sbt/Giter8TemplateResolver.scala
@@ -23,7 +23,7 @@ class Giter8TemplateResolver extends TemplateResolver {
       args.headOption match {
         case Some(Github(_, _)) => true
         case Some(Local(_))     => true
-        case Some(GitUrl(uri))  => uri.mkString("") endsWith (".g8")
+        case Some(GitUrl(uri))  => uri.mkString("") endsWith (".g8.git")
         case _                  => false
       }
     }


### PR DESCRIPTION
Ran into #7 when trying to create a new project from a g8 template in gitlab. After applying this change it works as expected.